### PR TITLE
Move createStyles into using callback

### DIFF
--- a/resources/ext.sectionAnchors.scripts.js
+++ b/resources/ext.sectionAnchors.scripts.js
@@ -1,9 +1,9 @@
 function createSectionAnchorButton( heading ) {
-	createStyles();
-
+	
 	var dfd = $.Deferred();
 	var modules = [ 'oojs-ui-widgets', 'oojs-ui.styles.icons-editing-core' ];
 	mw.loader.using( modules ).done( function () {
+		createStyles();
 		var $heading = $( heading ),
 			// h1, h2, h3, h4, h5, h6
 			$headingContainer = $heading.parent(),


### PR DESCRIPTION
There was an edge case on my mediawiki where <style> tags of the oo:ui were created after this one. That way the style of .sectionanchors-button was not top priority which lead to strange css layout. Could you please add this to REL1_41 branch as well? All the best, Stefan